### PR TITLE
Format specifier and close PWL source correctly

### DIFF
--- a/cell.cc
+++ b/cell.cc
@@ -177,7 +177,7 @@ static struct Hashtable *parse_measurements (const char *s, const char *param = 
       return H;
     }
 
-    b = hash_add (H, s);
+    b = hash_add (H, strdup(s));
     b->f = 0.0;
 
     s = strtok (NULL, " \t");

--- a/cell.cc
+++ b/cell.cc
@@ -89,16 +89,16 @@ static void unlink_generic_trace (const char *s)
 static void print_number (FILE *fp, double x)
 {
   if (x > 1e3) {
-    fprintf (fp, "%fK", x*1e-3);
+    fprintf (fp, "%.9gK", x*1e-3);
   }
   if (x > 1e-3) {
-    fprintf (fp, "%f", x);
+    fprintf (fp, "%.9g", x);
   }
   else if (x > 1e-9) {
-    fprintf (fp, "%fU", x*1e6);
+    fprintf (fp, "%.9gU", x*1e6);
   }
   else {
-    fprintf (fp, "%fP", x*1e12);
+    fprintf (fp, "%.9gP", x*1e12);
   }
 }
 
@@ -1432,6 +1432,7 @@ void Cell::_print_input_cap_cases (FILE *sfp, const char *prefix)
 	tm++;
       }
     }
+    fprintf (sfp, "+)\n\n");
   }
 }
 
@@ -2102,7 +2103,7 @@ int Cell::_run_dynamic ()
 	tm++;
       }
     }
-    fprintf (sfp, "\n");
+    fprintf (sfp, "+)\n\n");
   }
 
   fprintf (sfp, "\n.tran 0.1p ");

--- a/cell.cc
+++ b/cell.cc
@@ -177,7 +177,7 @@ static struct Hashtable *parse_measurements (const char *s, const char *param = 
       return H;
     }
 
-    b = hash_add (H, strdup(s));
+    b = hash_add (H, s);
     b->f = 0.0;
 
     s = strtok (NULL, " \t");


### PR DESCRIPTION
- Change number printing format to %.9g
- Close PWL source definition correctly with +)